### PR TITLE
Remove extra navbar buttons

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -78,6 +78,6 @@ ui <- navbarPage(
     # )
   ),
   collapsible = TRUE,
-  includeCSS("www/yeti.css"),
-  tags$head(includeHTML(("google-analytics.html")), tags$link(rel="shortcut icon", href="favicon.ico"))
+  theme = "yeti.css",
+  header = tags$head(includeHTML(("google-analytics.html")), tags$link(rel="shortcut icon", href="favicon.ico"))
 )


### PR DESCRIPTION
Hey Jasper, this is Umaseh, hope you're doing well! This is a really cool project by the way.

A tiny bug: 
There are extra clickable buttons in the navbar, one of which shows the entirety of yeti.css when clicked. 
![image](https://user-images.githubusercontent.com/7192567/79161950-5dcf4b00-7daa-11ea-9439-c4af3b1a6ee3.png)

I think this is because the stylesheet and the header tag are getting placed directly into the navbar, instead of specifically into the theme and header arguments of the navbarPage (see here: https://shiny.rstudio.com/reference/shiny/1.2.0/navbarPage.html)

I'm not 100% certain this fix will work on your server, because I'm not really familiar with running Shiny on Amazon clusters, but hopefully it helps!